### PR TITLE
add Warning Full Connection Pool (event)

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -30,7 +30,9 @@ Pool.prototype.getConnection = function (cb) {
 
   if (this._freeConnections.length > 0) {
     connection = this._freeConnections.shift();
-
+    if(this.config.warningFullConnectionPool) {
+        connection._stack = new Error().stack;
+    }
     return process.nextTick(function(){
       cb(null, connection);
     });
@@ -38,6 +40,9 @@ Pool.prototype.getConnection = function (cb) {
 
   if (this.config.connectionLimit === 0 || this._allConnections.length < this.config.connectionLimit) {
     connection = new PoolConnection(this, { config: this.config.connectionConfig });
+    if(this.config.warningFullConnectionPool) {
+        connection._stack = new Error().stack;
+    }
 
     this._allConnections.push(connection);
 
@@ -62,6 +67,13 @@ Pool.prototype.getConnection = function (cb) {
 
   if (this.config.queueLimit && this._connectionQueue.length >= this.config.queueLimit) {
     return cb(new Error('Queue limit reached.'));
+  }
+
+  if(this.config.warningFullConnectionPool) {
+    for(var i in this._allConnections) {
+      var conn = this._allConnections[i];
+      console.warn("Full Mysql Connection Pool - lastConnectionData\nstack : %s \nquery : %s\nquery stack : %s", conn._stack, conn._lastQuery, conn._lastCallStack);
+    }
   }
 
   if (cb && process.domain)

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -3,6 +3,7 @@ var Connection     = require('./Connection');
 var EventEmitter   = require('events').EventEmitter;
 var Util           = require('util');
 var PoolConnection = require('./PoolConnection');
+var WarningFullConnectionPoolEvent = require('./WarningFullConnectionPoolEvent');
 
 module.exports = Pool;
 
@@ -70,10 +71,7 @@ Pool.prototype.getConnection = function (cb) {
   }
 
   if(this.config.warningFullConnectionPool) {
-    for(var i in this._allConnections) {
-      var conn = this._allConnections[i];
-      console.warn("Full Mysql Connection Pool - lastConnectionData\nstack : %s \nquery : %s\nquery stack : %s", conn._stack, conn._lastQuery, conn._lastCallStack);
-    }
+    this.emit('warningFullConnectionPool', new WarningFullConnectionPoolEvent(this));
   }
 
   if (cb && process.domain)

--- a/lib/PoolConfig.js
+++ b/lib/PoolConfig.js
@@ -13,4 +13,7 @@ function PoolConfig(options) {
   this.queueLimit         = (options.queueLimit === undefined)
     ? 0
     : Number(options.queueLimit);
+  this.warningFullConnectionPool = (options.warningFullConnectionPool === undefined)
+    ? false
+    : Boolean(options.warningFullConnectionPool);
 }

--- a/lib/PoolConnection.js
+++ b/lib/PoolConnection.js
@@ -50,3 +50,12 @@ PoolConnection.prototype._removeFromPool = function(connection) {
 
   pool._removeConnection(this);
 };
+
+PoolConnection.prototype.query = function(sql, values, cb) {
+  if(this._pool.config.warningFullConnectionPool) {
+    this._lastQuery = sql;
+    this._lastCallStack = new Error().stack;
+  }
+  return PoolConnection.super_.prototype.query.apply(this, [sql, values, cb]);
+};
+

--- a/lib/PoolConnection.js
+++ b/lib/PoolConnection.js
@@ -54,7 +54,7 @@ PoolConnection.prototype._removeFromPool = function(connection) {
 PoolConnection.prototype.query = function(sql, values, cb) {
   if(this._pool.config.warningFullConnectionPool) {
     this._lastQuery = sql;
-    this._lastCallStack = new Error().stack;
+    this._lastQueryStack = new Error().stack;
   }
   return PoolConnection.super_.prototype.query.apply(this, [sql, values, cb]);
 };

--- a/lib/WarningFullConnectionPoolEvent.js
+++ b/lib/WarningFullConnectionPoolEvent.js
@@ -4,7 +4,7 @@ function WarningFullConnectionPoolEvent(pool) {
   this._pool = pool;
   this._data = [];
 
-  for(var i in pool._allConnections) {
+  for(var i=0; i<pool._allConnections.length; i++) {
     this._data.push(new ConnectionData(pool._allConnections[i]));
   }
 }

--- a/lib/WarningFullConnectionPoolEvent.js
+++ b/lib/WarningFullConnectionPoolEvent.js
@@ -1,0 +1,42 @@
+module.exports = WarningFullConnectionPoolEvent;
+
+function WarningFullConnectionPoolEvent(pool) {
+  this._pool = pool;
+  this._data = [];
+
+  for(var i in pool._allConnections) {
+    this._data.push(new ConnectionData(pool._allConnections[i]));
+  }
+}
+
+WarningFullConnectionPoolEvent.prototype.getData = function () {
+  return this._data;
+}
+
+function ConnectionData(conn) {
+  this._conn = conn;
+  this._stack = conn._stack;
+  this._lastQuery = conn._lastQuery;
+  this._lastQueryStack = conn._lastQueryStack;
+}
+
+ConnectionData.prototype.getStack = function () {
+  return this._stack;
+}
+
+ConnectionData.prototype.getLastQuery = function () {
+  return this._lastQuery;
+}
+
+ConnectionData.prototype.getLastQueryStack = function () {
+  return this._lastQueryStack;
+}
+
+ConnectionData.prototype.toString = function () {
+  var str = "";
+  str += "Full Mysql Connection Pool - lastConnectionData\n";
+  str += "stack : " + this.getStack() + "\n";
+  str += "query : " + this.getLastQuery() + "\n";
+  str += "query stack : " + this.getLastQueryStack() + "\n";
+  return str;
+}


### PR DESCRIPTION
Sometimes 'pool' is used without calling 'release', which is hard to detect.
By adding 'warningFullConnectionPool', developer can find unreleased pool with ease.

```
pool  = mysql.createPool({
  ....
  warningFullConnectionPool : true
});
pool.on('warningFullConnectionPool', function(e) {
  console.warn(e);
});
````