### PR TITLE
Fix for issue #964: connection error prevents pool from ending connection #964

### DIFF
--- a/lib/PoolConnection.js
+++ b/lib/PoolConnection.js
@@ -14,7 +14,12 @@ function PoolConnection(pool, options) {
   // the connection to end as well, thus we only need to watch for the end event
   // and we will be notified of disconnects.
   this.on('end', this._removeFromPool);
-  this.on('error', this._removeFromPool);
+
+  // we need this listener to avoid an exception
+  // but we can't call removeFromPool on error,
+  // otherwise the connection will be removed but not destroyed
+  // which may cause a stall
+  this.on('error', function() {});
 }
 
 PoolConnection.prototype.changeUser = function changeUser(options, callback) {

--- a/test/unit/pool/test-query-error.js
+++ b/test/unit/pool/test-query-error.js
@@ -1,0 +1,40 @@
+var assert = require('assert');
+var common = require('../../common');
+var pool   = common.createPool({
+  connectionLimit : 1,
+  port            : common.fakeServerPort
+});
+var server = common.createFakeServer();
+
+
+server.listen(common.fakeServerPort, function(err){
+  
+  pool.getConnection(function(err, conn) {
+
+    var socket_closed = false;
+
+	// socket should be closed after pool.end()
+    conn._socket.on('close', function() {
+      server.destroy();
+      socket_closed = true;
+    });
+
+	// an open socket will prevent the script from ending,
+	// hence the timeout
+	setTimeout( function() {
+		assert(socket_closed, true);
+		server.destroy();
+	}, 5000);
+
+	// attempt to make an invalid query
+	var seq = conn.query('');
+
+	// NOT listening to 'error' from seq
+		
+	seq.on('end', function() {
+      conn.release();
+      pool.end();  
+	});
+
+  });
+});


### PR DESCRIPTION
When an error event bubbled up to `PoolConnection`, `pool._removeFromPool` was being called, so the connection was being removed from the array but not destroyed. Then, when `pool.end` was called, the connection wasn't being ended, since we didn't have any reference to it anymore.

This pull request adds a test to cover that issue and fixes it by removing the call to `pool._removeFromPool` on connection error, since it's not necessary.