### PR TITLE
Added missing error callback, hanging services

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -88,6 +88,7 @@ Pool.prototype.acquireConnection = function acquireConnection(connection, cb) {
     if (err) {
       pool._connectionQueue.unshift(cb);
       pool._purgeConnection(connection);
+      cb(err);
       return;
     }
 


### PR DESCRIPTION
Added a missing callback that causes any services using the MySQL connection pool to hang when a ping to MySQL fails.  This often happens when connections have been idle for more than 8 hours in a typical MySQL setup, and oftentimes the "ping" request fails to MySQL.