### PR TITLE
Get formatted query from Pool.query() method

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -181,8 +181,8 @@ Connection.prototype.query = function(sql, values, cb) {
   }
   if (!query.isFormatted) {
     query.sql = this.format(query.sql, query.values);
+    query.isFormatted = true;
   }
-  query.isFormatted = true;
 
   return this._protocol._enqueue(query);
 };

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -179,8 +179,16 @@ Connection.prototype.query = function(sql, values, cb) {
   if (!(typeof sql == 'object' && 'typeCast' in sql)) {
     query.typeCast = this.config.typeCast;
   }
-
-  query.sql = this.format(query.sql, query.values);
+  //JM: modified
+  //query.sql = this.format(query.sql, query.values);
+  if (!query.isFormatted) {
+    query.sql = this.format(query.sql, query.values);
+    console.log("format() method called in Connection");
+  } else {
+    console.log("format() method skipped in Connection");
+  }
+  //JM: new line
+  query.isFormatted = true;
 
   return this._protocol._enqueue(query);
 };

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -179,15 +179,9 @@ Connection.prototype.query = function(sql, values, cb) {
   if (!(typeof sql == 'object' && 'typeCast' in sql)) {
     query.typeCast = this.config.typeCast;
   }
-  //JM: modified
-  //query.sql = this.format(query.sql, query.values);
   if (!query.isFormatted) {
     query.sql = this.format(query.sql, query.values);
-    console.log("format() method called in Connection");
-  } else {
-    console.log("format() method skipped in Connection");
   }
-  //JM: new line
   query.isFormatted = true;
 
   return this._protocol._enqueue(query);

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -171,7 +171,6 @@ Pool.prototype.end = function (cb) {
 Pool.prototype.query = function (sql, values, cb) {
   var query = Connection.createQuery(sql, values, cb);
 
-  //JM:(issue #984) added line
   query.isFormatted = false;
 
   if (!(typeof sql === 'object' && 'typeCast' in sql)) {
@@ -197,16 +196,11 @@ Pool.prototype.query = function (sql, values, cb) {
 
     conn.query(query);
   });
-  // JM: added
+
   if (!query.isFormatted) {
     query.isFormatted = true;
-    console.log("going to format in Pool.query");
     query.sql = this.format(query.sql, query.values);
-    console.log("format() method called");
-  } else {
-    console.log("format() method skipped");
   }
-  // JM:end
   return query;
 };
 
@@ -267,9 +261,7 @@ Pool.prototype.escapeId = function escapeId(value) {
   return mysql.escapeId(value, false);
 };
 
-//JM method:this.config.connectionConfig.
 Pool.prototype.format = function(sql, values) {
-  console.log(this.config.connectionConfig.queryFormat);
   if (typeof this.config.connectionConfig.queryFormat == "function") {
     return this.config.connectionConfig.queryFormat.call(this, sql, values, this.config.connectionConfig.timezone);
   }

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -171,6 +171,9 @@ Pool.prototype.end = function (cb) {
 Pool.prototype.query = function (sql, values, cb) {
   var query = Connection.createQuery(sql, values, cb);
 
+  //JM:(issue #984) added line
+  query.isFormatted = false;
+
   if (!(typeof sql === 'object' && 'typeCast' in sql)) {
     query.typeCast = this.config.connectionConfig.typeCast;
   }
@@ -194,7 +197,16 @@ Pool.prototype.query = function (sql, values, cb) {
 
     conn.query(query);
   });
-
+  // JM: added
+  if (!query.isFormatted) {
+    query.isFormatted = true;
+    console.log("going to format in Pool.query");
+    query.sql = this.format(query.sql, query.values);
+    console.log("format() method called");
+  } else {
+    console.log("format() method skipped");
+  }
+  // JM:end
   return query;
 };
 
@@ -253,6 +265,15 @@ Pool.prototype.escape = function(value) {
 
 Pool.prototype.escapeId = function escapeId(value) {
   return mysql.escapeId(value, false);
+};
+
+//JM method:this.config.connectionConfig.
+Pool.prototype.format = function(sql, values) {
+  console.log(this.config.connectionConfig.queryFormat);
+  if (typeof this.config.connectionConfig.queryFormat == "function") {
+    return this.config.connectionConfig.queryFormat.call(this, sql, values, this.config.connectionConfig.timezone);
+  }
+  return mysql.format(sql, values, this.config.connectionConfig.stringifyObjects, this.config.connectionConfig.timezone);
 };
 
 function spliceConnection(array, connection) {


### PR DESCRIPTION
### Solution to resolve #984
```javascript
var p= Pool.query(sql,data, function (){});
console.log(p.sql); // p.sql is not formatted
```
This commit changes the behavior of `Pool.query()` method so as to return the **formatted SQL statement** as expected, as in `Connection.query()`.
#### Preventing side effects
Since `Pool.query()` method uses `Connection.query()` internally, `Connection.query()` needs to know if  the SQL statement has already been formatted so as to prevent double formatting and corrupting the query.

A new Query object property `isFormatted` keeps track of formatting status.
#### Additional method
The `Pool.prototype.format` method was added to Pool module. Similar to `Connection.prototype.format` method and modified to work inside the Pool class.

#### Testing with error inducing query

```sql
SELECT name, rdate FROM contacts WHERE id = 1 OR name = 'John ? J ?'
```

Using the `Pool.query` method this query could be passed this way
```javascript
var columns = ['name', 'rdate'];
var userId = 1;
var userName="John ? J ?";
var sql_query = 'SELECT ?? FROM ?? WHERE id=? OR name=?';

var P = pool.query(search, [columns, 'contacts', userId, userName], function(err, rows, fields) {
		if (err) throw err;
		// do whatever
});
```
In the absence of the `isFormatted` property, if we allow the `Pool.query()` method to format *(escape and replace placeholders)* a query before it is passed to the `Connection.query` method, the latter will try to reformat the query a second time by replacing the `?` inside `'John ? J ?'` with another copy of the same string, resulting in an SQL error.

The addition of  the `isFormatted` property to the Query object is crucial for this fix to work. It is `undefined` by default and evaluates to `false` in a boolean operation. Therefore no change was made to the `lib/protocol/sequences/Query.js` file. The property is set after `Connection.createQuery()` method returns a Query object.