### PR TITLE
PoolCluster node remove method

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -442,6 +442,20 @@ poolCluster.add('MASTER', masterConfig);
 poolCluster.add('SLAVE1', slave1Config);
 poolCluster.add('SLAVE2', slave2Config);
 
+// remove manually
+poolCluster.remove('SLAVE2'); // By nodeId
+poolCluster.remove('SLAVE*'); // By target group : SLAVE1-2
+
+// event on manually removing (for each node)
+poolCluster.on('removeManually', function (nodeId) {
+  console.log('REMOVED MANUALLY NODE: ' + nodeId); // nodeId = SLAVE1
+});
+
+// event on auto removing (i.e. when connection was lost)
+poolCluster.on('remove', function (nodeId) {
+  console.log('REMOVED NODE : ' + nodeId); // nodeId = SLAVE1
+});
+
 // Target Group : ALL(anonymous, MASTER, SLAVE1-2), Selector : round-robin(default)
 poolCluster.getConnection(function (err, connection) {});
 
@@ -450,10 +464,6 @@ poolCluster.getConnection('MASTER', function (err, connection) {});
 
 // Target Group : SLAVE1-2, Selector : order
 // If can't connect to SLAVE1, return SLAVE2. (remove SLAVE1 in the cluster)
-poolCluster.on('remove', function (nodeId) {
-  console.log('REMOVED NODE : ' + nodeId); // nodeId = SLAVE1 
-});
-
 poolCluster.getConnection('SLAVE*', 'ORDER', function (err, connection) {});
 
 // of namespace : of(pattern, selector)

--- a/lib/PoolCluster.js
+++ b/lib/PoolCluster.js
@@ -63,6 +63,29 @@ PoolCluster.prototype.add = function(id, config) {
   }
 };
 
+PoolCluster.prototype.remove = function(pattern) {
+
+  var foundNodeIds = this._findNodeIds(pattern);
+
+  for (var i = 0, len = foundNodeIds.length; i < len; i++) {
+
+    var node = this._getNode(foundNodeIds[i]);
+
+    if (node !== null) {
+      var index = this._serviceableNodeIds.indexOf(node.id);
+      if (index !== -1) {
+        this._serviceableNodeIds.splice(index, 1);
+        delete this._nodes[ node.id ];
+        this._clearFindCaches();
+        node.pool.end();
+        this.emit('removeManually', node.id);
+      }
+    }
+
+  }
+
+};
+
 PoolCluster.prototype.getConnection = function(pattern, selector, cb) {
   var namespace;
   if (typeof pattern === 'function') {

--- a/test/unit/pool-cluster/test-connection-remove-by-name.js
+++ b/test/unit/pool-cluster/test-connection-remove-by-name.js
@@ -23,8 +23,11 @@ server.listen(common.fakeServerPort, function(err) {
         cluster.getConnection('SLAVE1', function (err, connection) {
             assert.ok(err);
             assert.equal(err.message, 'Pool does not exist.');
-            server.destroy();
         });
     });
 
 });
+
+setTimeout(function serverDestroy(){
+    server.destroy();
+}, 10000);

--- a/test/unit/pool-cluster/test-connection-remove-by-name.js
+++ b/test/unit/pool-cluster/test-connection-remove-by-name.js
@@ -1,0 +1,30 @@
+var assert  = require('assert');
+var common  = require('../../common');
+var cluster = common.createPoolCluster({defaultSelector: 'ORDER'});
+var server  = common.createFakeServer();
+
+var connCount  = 0;
+var poolConfig = common.getTestConfig({port: common.fakeServerPort});
+cluster.add('SLAVE1', poolConfig);
+
+server.listen(common.fakeServerPort, function(err) {
+    assert.ifError(err);
+
+    cluster.getConnection('SLAVE1', function (err, connection) {
+        assert.ifError(err);
+        assert.strictEqual(connection._clusterId, 'SLAVE1');
+
+        cluster.remove('SLAVE1');
+
+    });
+
+    cluster.on('removeManually', function(nodeId){
+        assert.strictEqual(nodeId, 'SLAVE1');
+        cluster.getConnection('SLAVE1', function (err, connection) {
+            assert.ok(err);
+            assert.equal(err.message, 'Pool does not exist.');
+            server.destroy();
+        });
+    });
+
+});

--- a/test/unit/pool-cluster/test-connection-remove-by-pattern.js
+++ b/test/unit/pool-cluster/test-connection-remove-by-pattern.js
@@ -3,7 +3,7 @@ var common  = require('../../common');
 var cluster = common.createPoolCluster({defaultSelector: 'ORDER'});
 var server  = common.createFakeServer();
 
-var connCount  = 0;
+var connCount  = 2;
 var poolConfig = common.getTestConfig({port: common.fakeServerPort});
 cluster.add('SLAVE1', poolConfig);
 cluster.add('SLAVE2', poolConfig);
@@ -37,4 +37,4 @@ server.listen(common.fakeServerPort, function(err) {
 
 setTimeout(function serverDestroy(){
     server.destroy();
-}, 2000);
+}, 10000);

--- a/test/unit/pool-cluster/test-connection-remove-by-pattern.js
+++ b/test/unit/pool-cluster/test-connection-remove-by-pattern.js
@@ -1,0 +1,40 @@
+var assert  = require('assert');
+var common  = require('../../common');
+var cluster = common.createPoolCluster({defaultSelector: 'ORDER'});
+var server  = common.createFakeServer();
+
+var connCount  = 0;
+var poolConfig = common.getTestConfig({port: common.fakeServerPort});
+cluster.add('SLAVE1', poolConfig);
+cluster.add('SLAVE2', poolConfig);
+
+server.listen(common.fakeServerPort, function(err) {
+    assert.ifError(err);
+
+    // added nodes
+    assert.deepEqual(cluster._serviceableNodeIds, ['SLAVE1', 'SLAVE2']);
+
+    // Test SLAVE1
+    cluster.getConnection('SLAVE1', function (err, connection) {
+        assert.strictEqual(connection._clusterId, 'SLAVE1');
+        cluster.remove('SLAVE1');
+    });
+
+    // Test SLAVE2
+    cluster.getConnection('SLAVE2', function (err, connection) {
+        assert.strictEqual(connection._clusterId, 'SLAVE2');
+        cluster.remove('SLAVE2');
+    });
+
+    cluster.on('removeManually', function(nodeId){
+        cluster.getConnection(nodeId, function (err, connection) {
+            assert.ok(err);
+            assert.strictEqual(err.message, 'Pool does not exist.');
+        });
+    });
+
+});
+
+setTimeout(function serverDestroy(){
+    server.destroy();
+}, 2000);


### PR DESCRIPTION
Added poolCluster.remove() method, which helps to remove nodes from cluster:

```js
// create
var poolCluster = mysql.createPoolCluster();

poolCluster.add(config); // anonymous group
poolCluster.add('MASTER', masterConfig);
poolCluster.add('SLAVE1', slave1Config);
poolCluster.add('SLAVE2', slave2Config);

// remove manually
poolCluster.remove('SLAVE2'); // By nodeId
poolCluster.remove('SLAVE*'); // By target group : SLAVE1-2

// event on manually removing (for each node)
poolCluster.on('removeManually', function (nodeId) {
  console.log('REMOVED MANUALLY NODE: ' + nodeId); // nodeId = SLAVE1
});

// event on auto removing (i.e. when connection was lost)
poolCluster.on('remove', function (nodeId) {
  console.log('REMOVED NODE : ' + nodeId); // nodeId = SLAVE1
});
```