### PR TITLE
Optimize SqlString.format

### DIFF
--- a/lib/protocol/SqlString.js
+++ b/lib/protocol/SqlString.js
@@ -66,16 +66,16 @@ SqlString.arrayToList = function(array, timeZone) {
 
 SqlString.format = function(sql, values, stringifyObjects, timeZone) {
   values = values == null ? [] : [].concat(values);
-
+  var index = 0;
   return sql.replace(/\?\??/g, function(match) {
-    if (!values.length) {
+    if (index>=values.length) {
       return match;
     }
 
     if (match == "??") {
-      return SqlString.escapeId(values.shift());
+      return SqlString.escapeId(values[index++]);
     }
-    return SqlString.escape(values.shift(), stringifyObjects, timeZone);
+    return SqlString.escape(values[index++], stringifyObjects, timeZone);
   });
 };
 


### PR DESCRIPTION
I was looking for ways to speed up mysql.format after noticing that the performance was *very* slow when attempting to format a query with 100,000+ values. I came up with a couple of improvements, by far the most significant is to use an iterator to step through the values array instead of Array.shift(). See: http://jsperf.com/some-array-reading-comparisons/6