### PR TITLE
readme: multiple statement clarification

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -220,7 +220,7 @@ issue [#501](https://github.com/felixge/node-mysql/issues/501). (Default: `'fals
    entrance ("long stack traces"). Slight performance penalty for most calls.
    (Default: `true`)
 * `multipleStatements`: Allow multiple mysql statements per query. Be careful
-  with this, it exposes you to SQL injection attacks. (Default: `false`)
+  with this, it could increase the scope of SQL injection attacks. (Default: `false`)
 * `flags`: List of connection flags to use other than the default ones. It is
   also possible to blacklist default ones. For more information, check
   [Connection Flags](#connection-flags).


### PR DESCRIPTION
Allowing multiple statement dosen't in itself expose you to sql injection attacks. It only does so if you already allow unsanitized input in your queries, which you should never do.

Maybe we should even change it to something like:

```diff
-Be careful with this, it could expose you to SQL injection attacks.
+Be careful with this, it could increase the scope of SQL injection attacks.
```

Or just remove the warning, thoughts?