### PR TITLE
switch user back to pool default on connection release

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -4,7 +4,12 @@ This file is a manually maintained list of changes for each release. Feel free
 to add your changes here when sending pull requests. Also send corrections if
 you spot any mistakes.
 
-## HEAD
+## NEXT_MINOR
+
+* Pool resets credentials to pool configuration on returned connection
+  instead of destroying after changeUser is called #837
+
+## v2.7.0 (2015-05-05)
 
 * Provide static require analysis
 

--- a/Readme.md
+++ b/Readme.md
@@ -390,7 +390,7 @@ addition to those options pools accept a few extras:
 
 ### connection
 
-The pool will emit a `connection` event when a new connection is made within the pool. 
+The pool will emit a `connection` event when a new connection is made within the pool.
 If you need to set session variables on the connection before it gets used, you can
 listen to the `connection` event.
 
@@ -459,7 +459,7 @@ poolCluster.getConnection('MASTER', function (err, connection) {});
 // Target Group : SLAVE1-2, Selector : order
 // If can't connect to SLAVE1, return SLAVE2. (remove SLAVE1 in the cluster)
 poolCluster.on('remove', function (nodeId) {
-  console.log('REMOVED NODE : ' + nodeId); // nodeId = SLAVE1 
+  console.log('REMOVED NODE : ' + nodeId); // nodeId = SLAVE1
 });
 
 poolCluster.getConnection('SLAVE*', 'ORDER', function (err, connection) {});
@@ -479,7 +479,7 @@ poolCluster.end(function (err) {
 
 ## PoolCluster Option
 * `canRetry`: If `true`, `PoolCluster` will attempt to reconnect when connection fails. (Default: `true`)
-* `removeNodeErrorCount`: If connection fails, node's `errorCount` increases. 
+* `removeNodeErrorCount`: If connection fails, node's `errorCount` increases.
   When `errorCount` is greater than `removeNodeErrorCount`, remove a node in the `PoolCluster`. (Default: `5`)
 * `restoreNodeTimeout`: If connection fails, specifies the number of milliseconds
   before another connection attempt will be made. If set to `0`, then node will be
@@ -518,6 +518,12 @@ The available options for this feature are:
 
 A sometimes useful side effect of this functionality is that this function also
 resets any connection state (variables, transactions, etc.).
+
+In the context of connection being returned to a Pool the connection will be
+reset back to the defaults for the pool before the connection is released to
+another `getConnection()` call.  When this happens the pool will emit
+`connection` to give the listener a chance to setup state on the connection
+again since it will have been reset.
 
 Errors encountered during this operation are treated as fatal connection errors
 by this module.

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -109,8 +109,11 @@ Pool.prototype.releaseConnection = function releaseConnection(connection) {
     }
 
     if (connection._purge) {
-      // purge connection from pool
-      this._purgeConnection(connection);
+      // restore the switched user
+      this.restoreUser(connection, function (err) {
+        if (err) return connection.destroy();
+        connection._pool.releaseConnection(connection);
+      });
       return;
     } else if (this._freeConnections.indexOf(connection) !== -1) {
       // connection already in free connection pool
@@ -246,6 +249,29 @@ Pool.prototype._removeConnection = function(connection) {
 
   this.releaseConnection(connection);
 };
+
+Pool.prototype.restoreUser = function restoreUser(connection, callback) {
+  var poolConfig = this.config.connectionConfig;
+  var pool = this;
+
+  var config = connection.config;
+  var user = poolConfig.user;
+  var database = poolConfig.database;
+  var password = poolConfig.password;
+
+  // only when credentials have been changed from the pool defaults
+  if (config.user !== user || config.database !== database || config.password !== password) {
+    connection.changeUser({ user: user, database: database, password: password }, function (err) {
+      if (err) return callback(err);
+      // emit as if it were a new connection so consumers can setup session state again
+      pool.emit('connection', connection);
+      callback(null);
+    });
+    connection._purge = false;
+  } else {
+    process.nextTick(callback);
+  }
+}
 
 Pool.prototype.escape = function(value) {
   return mysql.escape(value, this.config.connectionConfig.stringifyObjects, this.config.connectionConfig.timezone);

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -111,7 +111,7 @@ Pool.prototype.releaseConnection = function releaseConnection(connection) {
     if (connection._purge) {
       // restore the switched user
       this.restoreUser(connection, function (err) {
-        if (err) return connection.destroy();
+        if (err) return this._purgeConnection(connection);
         connection._pool.releaseConnection(connection);
       });
       return;

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -251,17 +251,14 @@ Pool.prototype._removeConnection = function(connection) {
 };
 
 Pool.prototype.restoreUser = function restoreUser(connection, callback) {
-  var poolConfig = this.config.connectionConfig;
   var pool = this;
 
+  var poolConfig = pool.config.connectionConfig;
   var config = connection.config;
-  var user = poolConfig.user;
-  var database = poolConfig.database;
-  var password = poolConfig.password;
 
   // only when credentials have been changed from the pool defaults
-  if (config.user !== user || config.database !== database || config.password !== password) {
-    connection.changeUser({ user: user, database: database, password: password }, function (err) {
+  if (config.user !== poolConfig.user || config.database !== poolConfig.database || config.password !== poolConfig.password || config.charset !== poolConfig.charset) {
+    connection.changeUser(poolConfig, function (err) {
       if (err) return callback(err);
       // emit as if it were a new connection so consumers can setup session state again
       pool.emit('connection', connection);

--- a/lib/PoolConnection.js
+++ b/lib/PoolConnection.js
@@ -8,7 +8,7 @@ inherits(PoolConnection, Connection);
 function PoolConnection(pool, options) {
   Connection.call(this, options);
   this._pool  = pool;
-  this._purge = false
+  this._purge = false;
 
   // When a fatal error occurs the connection's protocol ends, which will cause
   // the connection to end as well, thus we only need to watch for the end event
@@ -29,6 +29,7 @@ PoolConnection.prototype.changeUser = function changeUser(options, callback) {
 
 PoolConnection.prototype.release = function release() {
   var pool = this._pool;
+  var connection = this;
 
   if (!pool || pool._closed) {
     return;


### PR DESCRIPTION
reincarnation of #837...

> Discussed potential for this in #833 whereby a connection that is checked out from the pool then has `changeUser` called it would be marked for purging when it was released.  Instead during release `changeUser` is called again to restore it back to the pool configuration before it's released back into the pool.

> I've updated the test that covered restoreUser and all tests are passing locally, but I couldn't find a jshint or styleguide so I'm fully open to changes before merging.

@dougwilson you said it was ready to merge last year, but I guess something more important came up and I forgot to bump on it.  Would be good to get this change in.