### PR TITLE
Add support for custom streams

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -189,6 +189,8 @@ When establishing a connection, you can set the following options:
 * `localAddress`: The source IP address to use for TCP connection. (Optional)
 * `socketPath`: The path to a unix domain socket to connect to. When used `host`
   and `port` are ignored.
+* `stream`: A function that returns a Stream object that will be used
+  instead of the standard Net socket.
 * `user`: The MySQL user to authenticate as.
 * `password`: The password of that MySQL user.
 * `database`: Name of the database to use for this connection (Optional).

--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -83,10 +83,13 @@ Connection.prototype.connect = function connect(options, callback) {
   if (!this._connectCalled) {
     this._connectCalled = true;
 
-    // Connect either via a UNIX domain socket or a TCP socket.
-    this._socket = (this.config.socketPath)
-      ? Net.createConnection(this.config.socketPath)
-      : Net.createConnection(this.config.port, this.config.host);
+    if (this.config.stream) {
+      this._socket = this.config.stream();
+    } else if (this.config.socketPath) {
+      this._socket = Net.createConnection(this.config.socketPath)
+    } else {
+      this._socket = Net.createConnection(this.config.port, this.config.host);
+    }
 
     var connection = this;
     this._protocol.on('data', function(data) {

--- a/lib/ConnectionConfig.js
+++ b/lib/ConnectionConfig.js
@@ -13,6 +13,7 @@ function ConnectionConfig(options) {
   this.port               = options.port || 3306;
   this.localAddress       = options.localAddress;
   this.socketPath         = options.socketPath;
+  this.stream             = options.stream;
   this.user               = options.user || undefined;
   this.password           = options.password || undefined;
   this.database           = options.database;

--- a/test/unit/connection/test-custom-stream.js
+++ b/test/unit/connection/test-custom-stream.js
@@ -1,0 +1,39 @@
+var assert     = require('assert');
+var Net        = require('net');
+var common     = require('../../common');
+
+function streamFactory() {
+  return Net.connect({port: common.fakeServerPort});
+}
+
+var connection = common.createConnection({stream: streamFactory});
+
+var server = common.createFakeServer();
+var didConnect = false;
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+
+  connection.connect(function (err) {
+    assert.ifError(err);
+
+    assert.equal(didConnect, false);
+    didConnect = true;
+
+    connection.destroy();
+    server.destroy();
+  });
+});
+
+var hadConnection = false;
+server.on('connection', function(connection) {
+  connection.handshake();
+
+  assert.equal(hadConnection, false);
+  hadConnection = true;
+});
+
+process.on('exit', function() {
+    assert.equal(didConnect, true);
+    assert.equal(hadConnection, true);
+});


### PR DESCRIPTION
Hello,

I needed to connect to a SOCKS proxy, as in #725, so I added a `stream` option similar to the `mysql2` library. It only takes a factory function right now; I could add support for a plain stream, but that seems like a more unusual use case than typical.

I basically copied the socket connection test, because that seemed most appropriate. Let me know if you'd like me to DRY that up, or if you have feedback on anything else.