### PR TITLE
Replaced broken link with a more future-proof one

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -125,7 +125,7 @@ spend more time on it (ordered by time of contribution):
   video encoding as a service, check it out)
 * [Joyent](http://www.joyent.com/)
 * [pinkbike.com](http://pinkbike.com/)
-* [Holiday Extras](http://www.holidayextras.co.uk/) (they are [hiring](http://join.holidayextras.co.uk/vacancy/software-engineer-5/))
+* [Holiday Extras](http://www.holidayextras.co.uk/) (they are [hiring](http://join.holidayextras.co.uk/))
 * [Newscope](http://newscope.com/) (they are [hiring](http://www.newscope.com/stellenangebote))
 
 If you are interested in sponsoring a day or more of my time, please


### PR DESCRIPTION
The Holidy Extras "they are hiring" link directed users to a 404 page. I replaced it with the general careers page because the tech jobs section links to a specific job page that will be removed when the position is filled.