### PR TITLE
Fix streaming bug when using node-mysql with New Relic

### DIFF
--- a/lib/Connection.js
+++ b/lib/Connection.js
@@ -50,7 +50,7 @@ Connection.createQuery = function createQuery(sql, values, callback) {
       options[prop] = sql[prop];
     }
 
-    if (typeof values === 'function') {
+    if (typeof values === 'function' && values.length > 0) {
       cb = bindToCurrentDomain(values);
     } else if (values !== undefined) {
       options.values = values;
@@ -62,7 +62,7 @@ Connection.createQuery = function createQuery(sql, values, callback) {
   options.sql    = sql;
   options.values = values;
 
-  if (typeof values === 'function') {
+  if (typeof values === 'function' && values.length > 0) {
     cb = bindToCurrentDomain(values);
     options.values = undefined;
   }


### PR DESCRIPTION
Fixes #1153. New Relic wraps function invocations with some voodoo magic, inserting an empty function (with no parameters) along the way. In the Query constructor, node-mysql checks if the `value` parameter is a function and if it is, uses it as a callback. Because a legitimate query callback would expect arguments, checking the `length` property *before* setting `value` as the callback fixes New Relic's intrusion.

This is definitely a fix around New Relic, but because of their pervasiveness (more than one person reported the bug), here's a fix.