### PR TITLE
Update RowDataPacket.js

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -182,7 +182,7 @@ Pool.prototype.end = function (cb) {
 Pool.prototype.query = function (sql, values, cb) {
   var query = Connection.createQuery(sql, values, cb);
   
-  this.emit('query', query);
+  this.emit('query', query.sql, query.values);
 
   if (!(typeof sql === 'object' && 'typeCast' in sql)) {
     query.typeCast = this.config.connectionConfig.typeCast;

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -182,7 +182,7 @@ Pool.prototype.end = function (cb) {
 Pool.prototype.query = function (sql, values, cb) {
   var query = Connection.createQuery(sql, values, cb);
   
-  pool.emit('query', query);
+  this.emit('query', query);
 
   if (!(typeof sql === 'object' && 'typeCast' in sql)) {
     query.typeCast = this.config.connectionConfig.typeCast;

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -181,6 +181,8 @@ Pool.prototype.end = function (cb) {
 
 Pool.prototype.query = function (sql, values, cb) {
   var query = Connection.createQuery(sql, values, cb);
+  
+  pool.emit('query', query);
 
   if (!(typeof sql === 'object' && 'typeCast' in sql)) {
     query.typeCast = this.config.connectionConfig.typeCast;

--- a/lib/protocol/packets/RowDataPacket.js
+++ b/lib/protocol/packets/RowDataPacket.js
@@ -41,7 +41,7 @@ function parse(parser, fieldPackets, typeCast, nestTables, connection) {
 
     if (typeof nestTables == "string" && nestTables.length) {
       this[fieldPacket.table + nestTables + fieldPacket.name] = value;
-    } else if (nestTables) {
+    } else if (nestTables && fieldPacket.table !== '') {
       this[fieldPacket.table] = this[fieldPacket.table] || {};
       this[fieldPacket.table][fieldPacket.name] = value;
     } else {

--- a/test/integration/connection/test-connection-config-flags-affected-rows.js
+++ b/test/integration/connection/test-connection-config-flags-affected-rows.js
@@ -38,5 +38,7 @@ common.getTestConnection({flags: '-FOUND_ROWS'}, function (err, connection) {
     assert.strictEqual(2, result.affectedRows, 'primary key is the same, row is updated');
   });
 
+  connection.query('DROP TABLE ??', [table]);
+
   connection.end(assert.ifError);
 });

--- a/test/integration/connection/test-nested-tables-query.js
+++ b/test/integration/connection/test-nested-tables-query.js
@@ -9,7 +9,7 @@ common.getTestConnection(function (err, connection) {
   common.useTestDb(connection);
 
   connection.query([
-    'CREATE TEMPORARY TABLE ?? (',
+    'CREATE TABLE ?? (',
     '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
     '`title` varchar(255),',
     'PRIMARY KEY (`id`)',
@@ -31,6 +31,15 @@ common.getTestConnection(function (err, connection) {
     assert.equal(rows[0].nested_test_id, 1);
     assert.equal(rows[0].nested_test_title, 'test');
   });
+
+  connection.query({nestTables: true, sql: 'SELECT ??.id, (SELECT title FROM ?? WHERE title = \'test\') as title FROM ??', values: [table, table, table]}, function (err, rows) {
+    assert.ifError(err);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].nested_test.id, 1);
+    assert.equal(rows[0].title, 'test');
+  });
+
+  connection.query('DROP TABLE ??', [table]);
 
   connection.end(assert.ifError);
 });


### PR DESCRIPTION
When using subqueries in select statements, there's no table which means the data would be omitted if using nestTables. This fix only appends data to table objects if there is a table name, otherwise it's appended to the root object.