### PR TITLE
Update RowDataPacket.js

### DIFF
--- a/lib/protocol/packets/RowDataPacket.js
+++ b/lib/protocol/packets/RowDataPacket.js
@@ -41,7 +41,7 @@ function parse(parser, fieldPackets, typeCast, nestTables, connection) {
 
     if (typeof nestTables == "string" && nestTables.length) {
       this[fieldPacket.table + nestTables + fieldPacket.name] = value;
-    } else if (nestTables) {
+    } else if (nestTables && fieldPacket.table !== '') {
       this[fieldPacket.table] = this[fieldPacket.table] || {};
       this[fieldPacket.table][fieldPacket.name] = value;
     } else {

--- a/test/integration/connection/test-nested-tables-query.js
+++ b/test/integration/connection/test-nested-tables-query.js
@@ -9,7 +9,7 @@ common.getTestConnection(function (err, connection) {
   common.useTestDb(connection);
 
   connection.query([
-    'CREATE TEMPORARY TABLE ?? (',
+    'CREATE TABLE ?? (',
     '`id` int(11) unsigned NOT NULL AUTO_INCREMENT,',
     '`title` varchar(255),',
     'PRIMARY KEY (`id`)',
@@ -31,6 +31,15 @@ common.getTestConnection(function (err, connection) {
     assert.equal(rows[0].nested_test_id, 1);
     assert.equal(rows[0].nested_test_title, 'test');
   });
+
+  connection.query({nestTables: true, sql: 'SELECT ??.id, (SELECT title FROM ?? WHERE title = \'test\') as title FROM ??', values: [table, table, table]}, function (err, rows) {
+    assert.ifError(err);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].nested_test.id, 1);
+    assert.equal(rows[0].title, 'test');
+  });
+
+  connection.query('DROP TABLE ??', [table]);
 
   connection.end(assert.ifError);
 });


### PR DESCRIPTION
When using subqueries in select statements, there's no table which means the data would be omitted if using nestTables. This fix only appends data to table objects if there is a table name, otherwise it's appended to the root object.