### PR TITLE
Removed error handler when not having free connections, this error handler  is not possible to be catch

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -126,7 +126,7 @@ Pool.prototype.releaseConnection = function releaseConnection(connection) {
     if (this._freeConnections.indexOf(connection) !== -1) {
       // connection already in free connection pool
       // this won't catch all double-release cases
-      throw new Error('Connection already released');
+      // throw new Error('Connection already released');
     } else {
       // add connection to end of free queue
       this._freeConnections.push(connection);


### PR DESCRIPTION
Hi,

In the past I was using 2.1 version from mysql module, but this one was having some issues so I decided to upgrade to 2.9( a lot of good improvements), but when I did that i started to have this issues:

"Connection already released".

Because my code is something like this:


connection.query(sql, queryParams, function(err, rows) {
      connection.release();
.....
           connection.query(sql, queryParams, function(err, rows) {
     			connection.release();
......

I'm not able to bind an error even to the Pool.js

something like this:
pool.on("error", function(err){
    console.log("error");
});


So I'm creating this pull request, so there is a back compactibility.

Thanks :)
