### PR TITLE
Extend Pool methods to enable create conns even if there are free ones available

### DIFF
--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -28,48 +28,17 @@ Pool.prototype.getConnection = function (cb) {
   }
 
   var connection;
-  var pool = this;
 
   if (this._freeConnections.length > 0) {
     connection = this._freeConnections.shift();
-
     return this.acquireConnection(connection, cb);
   }
 
-  if (this.config.connectionLimit === 0 || this._allConnections.length < this.config.connectionLimit) {
-    connection = new PoolConnection(this, { config: this.config.newConnectionConfig() });
+  return this.createConnection(cb);
 
-    this._acquiringConnections.push(connection);
-    this._allConnections.push(connection);
-
-    return connection.connect({timeout: this.config.acquireTimeout}, function onConnect(err) {
-      spliceConnection(pool._acquiringConnections, connection);
-
-      if (pool._closed) {
-        err = new Error('Pool is closed.');
-      }
-
-      if (err) {
-        pool._purgeConnection(connection);
-        cb(err);
-        return;
-      }
-
-      pool.emit('connection', connection);
-      cb(null, connection);
-    });
-  }
-
-  if (!this.config.waitForConnections) {
-    return process.nextTick(function(){
-      return cb(new Error('No connections available.'));
-    });
-  }
-
-  this._enqueueCallback(cb);
 };
 
-Pool.prototype.getNewConnection = function (cb) {
+Pool.prototype.createConnection = function (cb) {
 
   if (this._closed) {
     return process.nextTick(function(){

--- a/lib/Pool.js
+++ b/lib/Pool.js
@@ -69,6 +69,50 @@ Pool.prototype.getConnection = function (cb) {
   this._enqueueCallback(cb);
 };
 
+Pool.prototype.getNewConnection = function (cb) {
+
+  if (this._closed) {
+    return process.nextTick(function(){
+      return cb(new Error('Pool is closed.'));
+    });
+  }
+
+  var connection;
+  var pool = this;
+
+  if (this.config.connectionLimit === 0 || this._allConnections.length < this.config.connectionLimit) {
+    connection = new PoolConnection(this, { config: this.config.newConnectionConfig() });
+
+    this._acquiringConnections.push(connection);
+    this._allConnections.push(connection);
+
+    return connection.connect({timeout: this.config.acquireTimeout}, function onConnect(err) {
+      spliceConnection(pool._acquiringConnections, connection);
+
+      if (pool._closed) {
+        err = new Error('Pool is closed.');
+      }
+
+      if (err) {
+        pool._purgeConnection(connection);
+        cb(err);
+        return;
+      }
+
+      pool.emit('connection', connection);
+      cb(null, connection);
+    });
+  }
+
+  if (!this.config.waitForConnections) {
+    return process.nextTick(function(){
+      return cb(new Error('No connections available.'));
+    });
+  }
+
+  this._enqueueCallback(cb);
+};
+
 Pool.prototype.acquireConnection = function acquireConnection(connection, cb) {
   if (connection._pool !== this) {
     throw new Error('Connection acquired from wrong pool.');

--- a/test/unit/pool/test-connection-create.js
+++ b/test/unit/pool/test-connection-create.js
@@ -1,0 +1,25 @@
+var assert = require('assert');
+var common = require('../../common');
+var Connection = common.Connection;
+var EventEmitter = require('events').EventEmitter;
+var pool = common.createPool({
+  port: common.fakeServerPort
+});
+var PoolConnection = common.PoolConnection;
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function(err) {
+  assert.ifError(err);
+
+  pool.createConnection(function(err, connection) {
+    assert.ifError(err);
+
+    assert(connection instanceof PoolConnection);
+    assert(connection instanceof Connection);
+    assert(connection instanceof EventEmitter);
+
+    connection.destroy();
+    server.destroy();
+  });
+});


### PR DESCRIPTION
As indicated on https://github.com/felixge/node-mysql/issues/1229 this PR proposes the extension of the functions in the Pool.js module to add a createConnection method that, compared to getConnection, does not acquire a "free" available connection but creates it. createConnection would then be used within getConnection in case there is no "free" available connections.

NOTE: This PR includes only one new unity test related to the new code. Although my plan is to extend the test suite on this PR, I would like to open it now and ask folks over here to provide input on how it could be improved, better tested and in general whether it would be beneficial to integrate this code change in the library. Please provide feedback :+1: 