### PR TITLE
Don't enqueue a quit sequence when destroying a PoolConnection.

### DIFF
--- a/lib/PoolConnection.js
+++ b/lib/PoolConnection.js
@@ -43,8 +43,8 @@ PoolConnection.prototype.end = function () {
 };
 
 PoolConnection.prototype.destroy = function () {
+  Connection.prototype.destroy.apply(this, arguments);
   this._removeFromPool(this);
-  return Connection.prototype.destroy.apply(this, arguments);
 };
 
 PoolConnection.prototype._removeFromPool = function _removeFromPool() {

--- a/test/unit/pool/test-destroy-connection-timeout.js
+++ b/test/unit/pool/test-destroy-connection-timeout.js
@@ -1,0 +1,26 @@
+
+var assert     = require('assert');
+var common     = require('../../common');
+var Connection = common.Connection;
+var pool       = common.createPool({port: common.fakeServerPort});
+
+var server = common.createFakeServer();
+
+server.listen(common.fakeServerPort, function (err) {
+  assert.ifError(err);
+  pool.getConnection(function (err, connection) {
+    assert.ifError(err);
+    process.nextTick(function() {
+      // Anything enqueued to the connection after this point cannot possibly
+      // be handled, and would keep the event loop alive until it times out.
+      connection.once('enqueue', function () {
+        throw new Error('PoolConnection.destroy should not enqueue anything');
+      })
+      connection.destroy();
+      pool.end(function (err) {
+        assert.ifError(err);
+        server.destroy();
+      })
+    })
+  })
+});


### PR DESCRIPTION
While trying to upgrade our app [1] to the latest version of node-mysql, we encountered test timeouts that seem to be due to a bug with the `PoolConnection` code leaving active timers waiting to fire.

Calling `PoolConnection.destroy()` invokes `Pool._purgeConnection`, which enqueues a `Quit` sequence via `Connection.end`.  It then destroys the underlying `Connection`, so the enqueued `Quit` will never get processed.  But the `Quit` sequence *does* set up a timeout timer, which keeps the node process alive for up to 30 seconds before firing.

This PR changes it to use `Pool._removeConnection` rather than `Pool._purgeConnection`.  AFAICT there's no need for the extra teardown that `_purgeConnection` does, since the connection is about to be destroyed anyway.  This prevents the `Quit` sequence from being enqueued and allows our tests to teardown cleanly without timing out.

(I tried to write a bit of a test for it as well, but I couldn't see an obvious way to test for this, so I resorted to poking around in the internals of the connection object).

[1] https://github.com/mozilla/fxa-auth-db-mysql/