### PR TITLE
Add JSON support in query and response

### DIFF
--- a/lib/protocol/sequences/Query.js
+++ b/lib/protocol/sequences/Query.js
@@ -9,10 +9,33 @@ var Readable     = require('readable-stream');
 module.exports = Query;
 Util.inherits(Query, Sequence);
 function Query(options, callback) {
+    
+    var orig=callback   
+    callback=function(err,body,obj){   
+      if(body && body.length && body.length>0){    
+        for (var i=0;i<body.length;i++){   
+          for(var j in body[i])    
+            try{   
+              var x=JSON.parse(body[i][j])    
+              if (typeof(x)!='number') body[i][j]=x
+            }    
+            catch(e){}   
+        }    
+      }    
+      orig.call(null,err,body,obj)   
+    }
+
   Sequence.call(this, options, callback);
 
   this.sql = options.sql;
   this.values = options.values;
+
+if(this.values)   
+for(var i in this.values){   
+if( this.values[i] && this.values[i].constructor.name=='Object') this.values[i]=JSON.stringify(this.values[i])   
+}    
+  
+
   this.typeCast = (options.typeCast === undefined)
     ? true
     : options.typeCast;


### PR DESCRIPTION
Now you can pass JSON object to insert/update queries, and it will stringify it.
When you run "select", it will automatically parse it to JSON object (if it success)

		conn=mysql.createPool({
			host:'localhost',
			user:'root',
			password:''
		})

		conn.query('select ?',[{obj:true}],function(err,rows){
			console.log(rows)
		})
