### PR TITLE
Flatten values array

### DIFF
--- a/lib/protocol/SqlString.js
+++ b/lib/protocol/SqlString.js
@@ -65,7 +65,7 @@ SqlString.arrayToList = function(array, timeZone) {
 };
 
 SqlString.format = function(sql, values, stringifyObjects, timeZone) {
-  values = values == null ? [] : [].concat(values);
+  values = values == null ? [] : [].concat.apply([], values);
 
   var index = 0;
   return sql.replace(/\?\??/g, function(match) {


### PR DESCRIPTION
If the intent is to flatten the values array this `[].concat(values)` is not doing it for me. Turns out this `[].concat.apply([], values)` does.

For example: http://jsfiddle.net/BloodyKnuckles/d7k7d0Lk/