### PR TITLE
Optimize escaping SQL

### DIFF
--- a/lib/protocol/SqlString.js
+++ b/lib/protocol/SqlString.js
@@ -1,10 +1,12 @@
 var SqlString = exports;
 
-SqlString.escapeId = function (val, forbidQualified) {
+SqlString.escapeId = function escapeId(val, forbidQualified) {
   if (Array.isArray(val)) {
-    return val.map(function(v) {
-      return SqlString.escapeId(v, forbidQualified);
-    }).join(', ');
+    var sql = '';
+    for (var i = 0; i < val.length; i++) {
+      sql += (i ? ', ' : '') + escapeId(val[i], forbidQualified);
+    }
+    return sql;
   }
 
   if (forbidQualified) {
@@ -57,11 +59,18 @@ SqlString.escape = function(val, stringifyObjects, timeZone) {
   return "'"+val+"'";
 };
 
-SqlString.arrayToList = function(array, timeZone) {
-  return array.map(function(v) {
-    if (Array.isArray(v)) return '(' + SqlString.arrayToList(v, timeZone) + ')';
-    return SqlString.escape(v, true, timeZone);
-  }).join(', ');
+SqlString.arrayToList = function arrayToList(array, timeZone) {
+  var sql = '';
+  for (var i = 0; i < array.length; i++) {
+    var v = array[i];
+    if (i) sql += ', ';
+    if (Array.isArray(v)) {
+      sql += '(' + arrayToList(v, timeZone) + ')';
+    } else {
+      sql += SqlString.escape(v, true, timeZone);
+    }
+  }
+  return sql;
 };
 
 SqlString.format = function(sql, values, stringifyObjects, timeZone) {
@@ -127,17 +136,17 @@ SqlString.bufferToString = function bufferToString(buffer) {
 };
 
 SqlString.objectToValues = function(object, timeZone) {
-  var values = [];
+  var sql = '';
   for (var key in object) {
     var value = object[key];
-    if(typeof value === 'function') {
+    if (typeof value === 'function') {
       continue;
     }
 
-    values.push(this.escapeId(key) + ' = ' + SqlString.escape(value, true, timeZone));
+    sql += (sql ? ', ' : '') + SqlString.escapeId(key) + ' = ' + SqlString.escape(value, true, timeZone);
   }
 
-  return values.join(', ');
+  return sql;
 };
 
 function zeroPad(number, length) {


### PR DESCRIPTION
In today's V8, appending to a string is faster than building an array and calling `.join()`.

### Benchmark

`$ npm install benchmark`

```js
'use strict';

var Benchmark = require('benchmark');
var SqlString = require('mysql/lib/protocol/SqlString');

var ids = ['id', 'name'];
var arrays = [['value', 12]];
var object = {
  id: 1,
  name: 'Some Name',
  email: 'somename@email.com',
  parentId: 20,
  notify: true,
};

new Benchmark.Suite()
  .add('escapeId', () => {
    SqlString.escapeId(ids);
  })
  .add('escape arrays', () => {
    SqlString.escape(arrays);
  })
  .add('escape object', () => {
    SqlString.escape(object);
  })
  .on('cycle', function(event) {
    console.log(String(event.target));
  })
  .run();
```

#### Results:

Test | Before (ops/sec) | After (ops/sec) | Speedup
------|-----------------------|--------------------|------------
`escapeId` | 1,260,802 | 1,771,151        | 40%
`escape arrays` | 1,037,337 | 2,384,038 | 130%
`escape object` | 279,876 | 456,599        | 63%