### PR TITLE
Improve performance of SqlString.escape()

### DIFF
--- a/lib/protocol/SqlString.js
+++ b/lib/protocol/SqlString.js
@@ -26,40 +26,21 @@ SqlString.escape = function escape(val, stringifyObjects, timeZone) {
   switch (typeof val) {
     case 'boolean': return (val) ? 'true' : 'false';
     case 'number': return val+'';
+    case 'object':
+      if (val instanceof Date) {
+        val = SqlString.dateToString(val, timeZone || 'local');
+      } else if (Array.isArray(val)) {
+        return SqlString.arrayToList(val, timeZone);
+      } else if (Buffer.isBuffer(val)) {
+        return SqlString.bufferToString(val);
+      } else if (stringifyObjects) {
+        val = val.toString();
+      } else {
+        return SqlString.objectToValues(val, timeZone);
+      }
   }
 
-  if (val instanceof Date) {
-    val = SqlString.dateToString(val, timeZone || 'local');
-  }
-
-  if (Buffer.isBuffer(val)) {
-    return SqlString.bufferToString(val);
-  }
-
-  if (Array.isArray(val)) {
-    return SqlString.arrayToList(val, timeZone);
-  }
-
-  if (typeof val === 'object') {
-    if (stringifyObjects) {
-      val = val.toString();
-    } else {
-      return SqlString.objectToValues(val, timeZone);
-    }
-  }
-
-  val = val.replace(/[\0\n\r\b\t\\\'\"\x1a]/g, function(s) {
-    switch(s) {
-      case "\0": return "\\0";
-      case "\n": return "\\n";
-      case "\r": return "\\r";
-      case "\b": return "\\b";
-      case "\t": return "\\t";
-      case "\x1a": return "\\Z";
-      default: return "\\"+s;
-    }
-  });
-  return "'"+val+"'";
+  return escapeString(val);
 };
 
 SqlString.arrayToList = function arrayToList(array, timeZone) {
@@ -155,6 +136,37 @@ SqlString.objectToValues = function objectToValues(object, timeZone) {
 
   return sql;
 };
+
+var charsRegex = /[\0\b\t\n\r\x1a\"\'\\]/g;
+var charsMap = {
+  '\0': '\\0',
+  '\b': '\\b',
+  '\t': '\\t',
+  '\n': '\\n',
+  '\r': '\\r',
+  '\x1a': '\\Z',
+  '"': '\\"',
+  '\'': '\\\'',
+  '\\': '\\\\'
+};
+function escapeString(val) {
+  var chunkIndex = charsRegex.lastIndex = 0;
+  var escapedVal = '';
+  var match;
+
+  while ((match = charsRegex.exec(val))) {
+    escapedVal += val.slice(chunkIndex, match.index) + charsMap[match[0]];
+    chunkIndex = charsRegex.lastIndex;
+  }
+
+  if (chunkIndex === 0) { // Nothing was escaped
+    return "'" + val + "'";
+  }
+  if (chunkIndex < val.length) {
+    return "'" + escapedVal + val.slice(chunkIndex) + "'";
+  }
+  return "'" + escapedVal + "'";
+}
 
 function zeroPad(number, length) {
   number = number.toString();

--- a/test/unit/protocol/test-SqlString.js
+++ b/test/unit/protocol/test-SqlString.js
@@ -76,38 +76,47 @@ test('SqlString.escape', {
 
   '\0 gets escaped': function() {
     assert.equal(SqlString.escape('Sup\0er'), "'Sup\\0er'");
+    assert.equal(SqlString.escape('Super\0'), "'Super\\0'");
   },
 
   '\b gets escaped': function() {
     assert.equal(SqlString.escape('Sup\ber'), "'Sup\\ber'");
+    assert.equal(SqlString.escape('Super\b'), "'Super\\b'");
   },
 
   '\n gets escaped': function() {
     assert.equal(SqlString.escape('Sup\ner'), "'Sup\\ner'");
+    assert.equal(SqlString.escape('Super\n'), "'Super\\n'");
   },
 
   '\r gets escaped': function() {
     assert.equal(SqlString.escape('Sup\rer'), "'Sup\\rer'");
+    assert.equal(SqlString.escape('Super\r'), "'Super\\r'");
   },
 
   '\t gets escaped': function() {
     assert.equal(SqlString.escape('Sup\ter'), "'Sup\\ter'");
+    assert.equal(SqlString.escape('Super\t'), "'Super\\t'");
   },
 
   '\\ gets escaped': function() {
     assert.equal(SqlString.escape('Sup\\er'), "'Sup\\\\er'");
+    assert.equal(SqlString.escape('Super\\'), "'Super\\\\'");
   },
 
   '\u001a (ascii 26) gets replaced with \\Z': function() {
     assert.equal(SqlString.escape('Sup\u001aer'), "'Sup\\Zer'");
+    assert.equal(SqlString.escape('Super\u001a'), "'Super\\Z'");
   },
 
   'single quotes get escaped': function() {
     assert.equal(SqlString.escape('Sup\'er'), "'Sup\\'er'");
+    assert.equal(SqlString.escape('Super\''), "'Super\\''");
   },
 
   'double quotes get escaped': function() {
     assert.equal(SqlString.escape('Sup"er'), "'Sup\\\"er'");
+    assert.equal(SqlString.escape('Super"'), "'Super\\\"'");
   },
 
   'dates are converted to YYYY-MM-DD HH:II:SS.sss': function() {


### PR DESCRIPTION
Strategies include:
+ Manually escaping strings rather than using a string replace function with a regex
+ Only calling `typeof` on the input value once
+ Not performing extra type checks if the input type has already been determined

#### Benchmark

See [this gist](https://gist.github.com/nwoltman/98dcc294b77da3bedad9bb89e54ab2fa) for the code.

| Value | Before (ops/sec) | This PR (ops/sec) | Speedup (`PR/before`) |
|---------|----------------------|------------------------|-------------|
| `'lastname'` | 4,916,714 | 13,443,318 | 2.73 |
| `'firstname123@gmail.com'` | 4,843,172 | 13,258,714 | 2.74 |
| `'to "escape"'` | 1,846,340 | 3,510,579 | 1.90 |
| `'Lorem ipsum...'` | 1,724,015 | 2,212,050 | 1.28 |
| `'Lorem ipsum...'` with `'\n'` | 845,988 | 1,346,465 | 1.59 |
| JSON | 486,268 | 493,629 | 1.02 |