### PR TITLE
Update to queryFormat example in Readme: allow named params optionally

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -728,6 +728,7 @@ Here's an example of how to implement another format:
 ```js
 connection.config.queryFormat = function (query, values) {
   if (!values) return query;
+  if (Array.isArray(values)) return mysql.format(query. values);
   return query.replace(/\:(\w+)/g, function (txt, key) {
     if (values.hasOwnProperty(key)) {
       return this.escape(values[key]);


### PR DESCRIPTION
Updated the queryFormat example to allow the optional use of named params, but continue to support the normal array-style params simultaneously.