### PR TITLE
Performance improvements for formatting in SqlString

### DIFF
--- a/lib/protocol/SqlString.js
+++ b/lib/protocol/SqlString.js
@@ -72,20 +72,42 @@ SqlString.arrayToList = function arrayToList(array, timeZone) {
 };
 
 SqlString.format = function format(sql, values, stringifyObjects, timeZone) {
-  values = values == null ? [] : [].concat(values);
+  if (values == null) {
+    return sql;
+  }
 
-  var index = 0;
-  return sql.replace(/\?\??/g, function(match) {
-    if (index === values.length) {
-      return match;
-    }
+  if (!(values instanceof Array || Array.isArray(values))) {
+    values = [values];
+  }
 
-    var value = values[index++];
+  var valuesIndex = 0;
+  var chunkIndex = 0;
+  var placeholdersRegex = /\?\??/g;
+  var result = '';
+  var match;
 
-    return match === '??'
-      ? SqlString.escapeId(value)
-      : SqlString.escape(value, stringifyObjects, timeZone);
-  });
+  while (valuesIndex < values.length && (match = placeholdersRegex.exec(sql))) {
+    var value = values[valuesIndex++];
+
+    result += sql.slice(chunkIndex, match.index) + (
+      match[0] === '??'
+        ? SqlString.escapeId(value)
+        : SqlString.escape(value, stringifyObjects, timeZone)
+    );
+
+    chunkIndex = placeholdersRegex.lastIndex;
+  }
+
+  if (chunkIndex === 0) {
+    // Nothing was replaced
+    return sql;
+  }
+
+  if (chunkIndex < sql.length) {
+    result += sql.slice(chunkIndex);
+  }
+
+  return result;
 };
 
 SqlString.dateToString = function dateToString(date, timeZone) {

--- a/test/unit/protocol/test-SqlString.js
+++ b/test/unit/protocol/test-SqlString.js
@@ -180,5 +180,15 @@ test('SqlString.format', {
 
     var sql = SqlString.format('?', { toString: function () { return 'hello'; } }, true);
     assert.equal(sql, "'hello'");
+  },
+
+  'sql is untouched if no values are provided': function () {
+    var sql = SqlString.format('SELECT ??');
+    assert.equal(sql, 'SELECT ??');
+  },
+
+  'sql is untouched if values are provided but there are no placeholders': function () {
+    var sql = SqlString.format('SELECT COUNT(*) FROM table', ['a', 'b']);
+    assert.equal(sql, 'SELECT COUNT(*) FROM table');
   }
 });


### PR DESCRIPTION
Improve performance by:
+ Returning early if there are no values to use for formatting
+ Not copying the `values` argument if it is already an Array
+ Parsing the SQL string using the technique from #1390

#### Benchmark Results

| Query | Before (ops/sec) | This PR (ops/sec) | Speedup (`PR/before`) |
|----------|----------------------|------------------------|-------------|
| no values | 1,733,030 | 48,704,838 | 28 |
| 1) simple query | 759,563 | 1,925,109 | 2.5 |
| 2) more values | 582,647 | 1,098,441 | 1.9 |
| 3) a lot of values | 366,547 | 507,246 | 1.4 |
| 4) long query string, few values | 647,084 | 1,772,840 | 2.7 |

See [this gist](https://gist.github.com/nwoltman/7de8311bb69b56bb0002265ad0e5df97) for the code.